### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-#Bootstrap 3 Offline Docs
+# Bootstrap 3 Offline Docs
 
 *Up to date with v3.3.5*
 
-##Usage
+## Usage
 
 1. Download the [files](https://github.com/AAlakkad/Bootstrap-3-Offline-Docs/archive/master.zip).
 2. Extract zip file.
 3. Open `index.html` in a browser.
 
 
-##Note
+## Note
 You can compile the official docs yourself with Jekyll.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
